### PR TITLE
UBS projectId 

### DIFF
--- a/assets/plannings.json
+++ b/assets/plannings.json
@@ -18,12 +18,12 @@
                   {
                     "id": "gr1g",
                     "title": "GR 1 G",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=726&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=726&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr1t",
                     "title": "GR 1 T",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1508&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1508&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -34,12 +34,12 @@
                   {
                     "id": "gr2g",
                     "title": "GR 2 G",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=730&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=730&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr2t",
                     "title": "GR 2 T",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1649&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1649&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -50,12 +50,12 @@
                   {
                     "id": "gr3g",
                     "title": "GR 3 G",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=731&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=731&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr3t",
                     "title": "GR 3 T",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1680&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1680&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -66,12 +66,12 @@
                   {
                     "id": "gr4g",
                     "title": "GR 4 G",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=706&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=706&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr4t",
                     "title": "GR 4 T",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1698&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1698&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -82,12 +82,12 @@
                   {
                     "id": "gr5g",
                     "title": "GR 5 G",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=733&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=733&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr5t",
                     "title": "GR 5 T",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1715&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1715&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -98,12 +98,12 @@
                   {
                     "id": "gr6g",
                     "title": "GR 6 G",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=707&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=707&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr6t",
                     "title": "GR 6 T",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5805&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5805&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -114,72 +114,72 @@
                   {
                     "id": "soutienanglaisa",
                     "title": "Soutien Anglais A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3400&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3400&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienanglaisb",
                     "title": "Soutien Anglais B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3403&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3403&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienanglaisc",
                     "title": "Soutien Anglais C",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3404&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3404&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutiencomptaa",
                     "title": "Soutien Compta A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7957&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7957&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutiencomptab",
                     "title": "Soutien Compta B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7958&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7958&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienlfa",
                     "title": "Soutien LF A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4816&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4816&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienlfb",
                     "title": "Soutien LF B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7834&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7834&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienlfc",
                     "title": "Soutien LF C",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7835&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7835&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienmathsa",
                     "title": "Soutien Maths A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4501&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4501&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienmathsb",
                     "title": "Soutien Maths B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4722&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4722&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienmathsc",
                     "title": "Soutien Maths C",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4624&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4624&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienmathsd",
                     "title": "Soutien Maths D",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3395&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3395&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienmathse",
                     "title": "Soutien Maths E",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4727&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4727&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "soutienmathsf",
                     "title": "Soutien Maths F",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1037&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1037&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -196,12 +196,12 @@
                   {
                     "id": "cg2pall",
                     "title": "CG2P All",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1981&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1981&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "cg2pesp",
                     "title": "CG2P Esp",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3584&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3584&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -212,12 +212,12 @@
                   {
                     "id": "gc2f-aall",
                     "title": "GC2F-A All",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1884&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1884&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gc2f-aesp",
                     "title": "GC2F-A Esp",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3586&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3586&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -228,7 +228,7 @@
                   {
                     "id": "gc2f-i",
                     "title": "GC2F-I",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1803&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1803&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -239,12 +239,12 @@
                   {
                     "id": "gema-faall",
                     "title": "GEMA-FA ALL",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3582&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3582&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gema-faesp",
                     "title": "GEMA-FA Esp",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1274&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1274&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -255,12 +255,12 @@
                   {
                     "id": "gema-fi1all",
                     "title": "GEMA-FI1 All",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3587&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3587&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gema-fi1esp",
                     "title": "GEMA-FI1 Esp",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3402&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3402&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -271,7 +271,7 @@
                   {
                     "id": "gema-fi2",
                     "title": "GEMA-FI2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1290&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1290&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -282,12 +282,12 @@
                   {
                     "id": "gprhall",
                     "title": "GPRH All",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2016&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2016&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gprhesp",
                     "title": "GPRH Esp",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3513&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3513&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -310,12 +310,12 @@
                   {
                     "id": "gr1a1",
                     "title": "GR 1A1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3543&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3543&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr1a2",
                     "title": "GR 1A2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3542&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3542&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -326,12 +326,12 @@
                   {
                     "id": "gr1b1",
                     "title": "GR 1B1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3538&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3538&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr1b2",
                     "title": "GR 1B2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3535&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3535&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -342,12 +342,12 @@
                   {
                     "id": "gr1c1",
                     "title": "GR 1C1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3532&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3532&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr1c2",
                     "title": "GR 1C2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3530&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3530&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -358,12 +358,12 @@
                   {
                     "id": "gr1d1",
                     "title": "GR 1D1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3527&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3527&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr1d2",
                     "title": "GR 1D2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3525&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3525&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -380,12 +380,12 @@
                   {
                     "id": "gr2a1",
                     "title": "GR 2A1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3487&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3487&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr2a2",
                     "title": "GR 2A2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3486&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3486&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -396,12 +396,12 @@
                   {
                     "id": "gr2b1",
                     "title": "GR 2B1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3484&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3484&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr2b2",
                     "title": "GR 2B2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3483&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3483&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -412,12 +412,12 @@
                   {
                     "id": "gr2c1",
                     "title": "GR 2C1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3479&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3479&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gr2c2",
                     "title": "GR 2C2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3478&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3478&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -430,12 +430,12 @@
               {
                 "id": "gr2d1",
                 "title": "GR 2D1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4294&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4294&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gr2d2",
                 "title": "GR 2D2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4296&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4296&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -448,32 +448,32 @@
           {
             "id": "e-commnalt",
             "title": "E-COMMN ALT",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5252&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5252&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpc2a",
             "title": "LP C2A",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4226&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4226&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpcd",
             "title": "LP CD",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3508&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3508&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpcgid",
             "title": "LP CGID",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3510&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3510&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpcgidalt",
             "title": "LP CGID ALT",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5877&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5877&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpcsdalt",
             "title": "LP CSD ALT",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3577&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3577&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpdlis",
@@ -482,19 +482,19 @@
               {
                 "id": "lpdlisgrp1",
                 "title": "LP DLIS Grp 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3997&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3997&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "lpdlisgrp2",
                 "title": "LP DLIS Grp 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4209&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4209&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
           {
             "id": "lpgabi",
             "title": "LP GABI",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1849&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1849&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "lpmds",
@@ -507,17 +507,17 @@
                   {
                     "id": "lpsdmalt",
                     "title": "LP SDM ALT",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1359&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1359&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "sdm-a",
                     "title": "SDM-A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6791&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6791&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "sdm-b",
                     "title": "SDM-B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6800&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6800&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -528,17 +528,17 @@
                   {
                     "id": "lpsisalt",
                     "title": "LP SIS ALT",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1890&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1890&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "sis-a",
                     "title": "SIS-A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6787&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6787&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "sis-b",
                     "title": "SIS-B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6789&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6789&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -547,13 +547,13 @@
           {
             "id": "pmnc",
             "title": "PMNC",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2876&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2876&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           }
         ]
       },
       {
         "id": "butdutstid",
-        "title": "BUT STID",
+        "title": "BUT SD",
         "edts": [
           {
             "id": "1ereannee",
@@ -566,12 +566,12 @@
                   {
                     "id": "groupe1a1",
                     "title": "Groupe 1A1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3467&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3467&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe1a2",
                     "title": "Groupe 1A2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3466&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3466&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -582,12 +582,12 @@
                   {
                     "id": "groupe1b1",
                     "title": "Groupe 1B1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3464&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3464&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe1b2",
                     "title": "Groupe 1B2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3463&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3463&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -598,12 +598,12 @@
                   {
                     "id": "groupe1c1",
                     "title": "Groupe 1C1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3461&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3461&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe1c2",
                     "title": "Groupe 1C2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3460&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3460&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -614,12 +614,12 @@
                   {
                     "id": "groupe1d1",
                     "title": "Groupe 1D1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3458&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3458&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe1d2",
                     "title": "Groupe 1D2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3457&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3457&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -636,12 +636,12 @@
                   {
                     "id": "groupe2ae",
                     "title": "Groupe 2AE",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3453&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3453&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe2av",
                     "title": "Groupe 2AV",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3454&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3454&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -652,12 +652,12 @@
                   {
                     "id": "groupe2be",
                     "title": "Groupe 2BE",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3450&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3450&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe2bv",
                     "title": "Groupe 2BV",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3451&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3451&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -668,12 +668,12 @@
                   {
                     "id": "groupe2ce",
                     "title": "Groupe 2CE",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3447&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3447&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe2cv",
                     "title": "Groupe 2CV",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3448&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3448&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -684,12 +684,12 @@
                   {
                     "id": "groupe2de",
                     "title": "Groupe 2DE",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1299&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1299&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe2dv",
                     "title": "Groupe 2DV",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1189&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1189&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -702,12 +702,12 @@
               {
                 "id": "allemand",
                 "title": "Allemand",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3492&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3492&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "espagnol",
                 "title": "Espagnol",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3493&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3493&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -728,12 +728,12 @@
                   {
                     "id": "groupe11",
                     "title": "Groupe 1.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3438&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3438&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe12",
                     "title": "Groupe 1.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3436&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3436&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -744,12 +744,12 @@
                   {
                     "id": "groupe21",
                     "title": "Groupe 2.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3433&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3433&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe22",
                     "title": "Groupe 2.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3431&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3431&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -760,12 +760,12 @@
                   {
                     "id": "groupe31",
                     "title": "Groupe 3.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3429&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3429&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe32",
                     "title": "Groupe 3.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3428&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3428&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -776,12 +776,12 @@
                   {
                     "id": "groupe41",
                     "title": "Groupe 4.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3426&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3426&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupe42",
                     "title": "Groupe 4.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3425&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3425&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -798,12 +798,12 @@
                   {
                     "id": "etudparcours11",
                     "title": "Etud Parcours 1.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3387&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3387&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "etudparcours12",
                     "title": "Etud Parcours 1.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3585&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3585&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -814,12 +814,12 @@
                   {
                     "id": "etudparcours21",
                     "title": "Etud Parcours 2.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3580&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3580&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "etudparcours22",
                     "title": "Etud Parcours 2.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=71&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=71&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -830,12 +830,12 @@
                   {
                     "id": "etudparcours31",
                     "title": "Etud Parcours 3.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2883&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2883&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "etudparcours32",
                     "title": "Etud Parcours 3.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2902&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2902&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -846,12 +846,12 @@
                   {
                     "id": "etudparcours31",
                     "title": "Etud Parcours 3.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2808&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2808&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "etudparcours32",
                     "title": "Etud Parcours 3.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2811&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2811&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -862,12 +862,12 @@
                   {
                     "id": "etudparcours41",
                     "title": "Etud Parcours 4.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2814&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2814&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "etudparcours42",
                     "title": "Etud Parcours 4.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2836&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2836&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -884,12 +884,12 @@
                   {
                     "id": "groupea1",
                     "title": "Groupe A.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3421&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3421&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupea2",
                     "title": "Groupe A.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3420&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3420&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -900,12 +900,12 @@
                   {
                     "id": "groupeb1",
                     "title": "Groupe B.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3412&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3412&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupeb2",
                     "title": "Groupe B.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3411&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3411&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -916,12 +916,12 @@
                   {
                     "id": "groupec1",
                     "title": "Groupe C.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3415&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3415&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "groupec2",
                     "title": "Groupe C.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3414&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3414&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -932,12 +932,12 @@
                   {
                     "id": "grouped1",
                     "title": "Groupe D.1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3418&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3418&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "grouped2",
                     "title": "Groupe D.2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3417&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3417&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1466,32 +1466,32 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=85&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=85&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=334&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=334&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp3",
                     "title": "TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3733&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3733&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp4",
                     "title": "TP4",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3851&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3851&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp5",
                     "title": "TP5",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7198&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7198&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp6",
                     "title": "TP6",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7200&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7200&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1502,32 +1502,32 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4770&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4770&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4838&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4838&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp3",
                     "title": "TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5256&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5256&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp4",
                     "title": "TP4",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4473&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4473&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp5",
                     "title": "TP5",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7204&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7204&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp6",
                     "title": "TP6",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7203&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7203&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1544,32 +1544,32 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2860&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2860&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4517&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4517&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp3",
                     "title": "TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4938&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4938&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp4",
                     "title": "TP4",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4948&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4948&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp5",
                     "title": "TP5",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6024&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6024&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp6",
                     "title": "TP6",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6052&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6052&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1580,32 +1580,32 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4866&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4866&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4848&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4848&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp3",
                     "title": "TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4820&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4820&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp4",
                     "title": "TP4",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4821&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4821&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp5",
                     "title": "TP5",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6102&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6102&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp6",
                     "title": "TP6",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6125&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6125&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1618,32 +1618,32 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4965&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4965&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4958&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4958&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp3",
                 "title": "TP3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2422&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2422&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp4",
                 "title": "TP4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2424&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2424&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp5",
                 "title": "TP5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4983&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4983&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp6",
                 "title": "TP6",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4989&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4989&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -1664,12 +1664,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1026&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1026&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=701&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=701&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1680,12 +1680,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5132&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5132&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5145&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5145&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1702,12 +1702,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1771&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1771&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1773&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1773&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1718,12 +1718,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=645&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=645&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6371&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6371&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1736,12 +1736,12 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=887&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=887&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2764&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2764&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -1762,12 +1762,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4426&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4426&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4527&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4527&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1778,12 +1778,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5258&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5258&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4096&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4096&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1800,12 +1800,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=154&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=154&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4176&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4176&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1816,12 +1816,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2187&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2187&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2239&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2239&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1838,7 +1838,7 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6371&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6371&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1861,12 +1861,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5819&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5819&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=141&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=141&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1877,12 +1877,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2835&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2835&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7205&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7205&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1899,12 +1899,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1120&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1120&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1578&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1578&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1915,12 +1915,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1938&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1938&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1203&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1203&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -1933,17 +1933,17 @@
               {
                 "id": "m2oppi",
                 "title": "M2OPPI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp1contratpro",
                 "title": "TP1 (Contrat Pro)",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=155&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=155&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2 (Parcours GI)",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1047&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1047&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -1964,12 +1964,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4620&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4620&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4579&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4579&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -1980,12 +1980,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5027&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5027&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5105&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5105&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -2002,12 +2002,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2540&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2540&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2570&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2570&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -2018,12 +2018,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2635&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2635&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2698&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2698&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -2046,12 +2046,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2060&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2060&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2026&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2026&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -2062,12 +2062,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2863&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2863&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4300&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4300&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -2084,12 +2084,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1139&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1139&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2043&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2043&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -2100,12 +2100,12 @@
                   {
                     "id": "tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2866&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2866&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2046&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2046&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -2118,27 +2118,27 @@
               {
                 "id": "cpro",
                 "title": "CPro",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5069&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5069&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "i-mars",
                 "title": "I-MARS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6280&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6280&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mmgm",
                 "title": "MMGM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2459&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2459&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7819&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7819&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6233&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6233&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2161,17 +2161,17 @@
               {
                 "id": "info1",
                 "title": "INFO 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4087,4675&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4087,4675&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "info2",
                 "title": "INFO 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3721,2353&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3721,2353&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "info3",
                 "title": "INFO 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5994&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5994&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2182,22 +2182,22 @@
               {
                 "id": "info1",
                 "title": "INFO 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=427,2234&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=427,2234&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "info2",
                 "title": "INFO 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4796,6555&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4796,6555&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "info3",
                 "title": "INFO 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4389,2544&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4389,2544&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "info4",
                 "title": "INFO 4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4434,2615&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4434,2615&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2214,7 +2214,7 @@
               {
                 "id": "groupe1",
                 "title": "Groupe 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4118,4566&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4118,4566&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2225,7 +2225,7 @@
               {
                 "id": "groupe1",
                 "title": "Groupe 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2022,732&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2022,732&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2242,12 +2242,12 @@
               {
                 "id": "statinfo",
                 "title": "Stat Info",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2896,2672&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2896,2672&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "statmath",
                 "title": "Stat Math",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5419,6514&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5419,6514&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2258,12 +2258,12 @@
               {
                 "id": "stat1",
                 "title": "Stat 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4545,2722&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4545,2722&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "stat2",
                 "title": "Stat 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2118,7094&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2118,7094&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2280,12 +2280,12 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1901&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1901&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2223&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2223&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2296,12 +2296,12 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1920&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1920&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1945&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1945&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2312,12 +2312,12 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1894&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1894&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1895&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1895&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2334,12 +2334,12 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=636&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=636&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6702&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6702&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2350,27 +2350,27 @@
               {
                 "id": "gr1",
                 "title": "Gr1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1569&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1569&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gr2",
                 "title": "Gr2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1570&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1570&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gr3",
                 "title": "Gr3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2472&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2472&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "me",
                 "title": "ME",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5119&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5119&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "pc",
                 "title": "PC",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5111&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5111&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2381,12 +2381,12 @@
               {
                 "id": "tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5417&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5417&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5421&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5421&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2409,62 +2409,62 @@
               {
                 "id": "g1",
                 "title": "G1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4367&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4367&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g2",
                 "title": "G2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4365&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4365&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g3",
                 "title": "G3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4363&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4363&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g4",
                 "title": "G4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6849&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6849&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g5",
                 "title": "G5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4353&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4353&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g6",
                 "title": "G6",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4347&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4347&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g7",
                 "title": "G7",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4344&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4344&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g8",
                 "title": "G8",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4342&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4342&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g9",
                 "title": "G9",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4339&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4339&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g10",
                 "title": "G10",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3716&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3716&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g11",
                 "title": "G11",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=188&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=188&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g12",
                 "title": "G12",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7872&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7872&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2475,47 +2475,47 @@
               {
                 "id": "g1",
                 "title": "G1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4490&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4490&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g2",
                 "title": "G2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4489&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4489&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g3",
                 "title": "G3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4488&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4488&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g4",
                 "title": "G4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4487&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4487&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g5",
                 "title": "G5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4772&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4772&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g6",
                 "title": "G6",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=771&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=771&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g7",
                 "title": "G7",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5036&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5036&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g8",
                 "title": "G8",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5967&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5967&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2d",
                 "title": "L2D",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=632&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=632&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2526,37 +2526,37 @@
               {
                 "id": "mixte-groupe1",
                 "title": "Mixte - Groupe 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1503&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1503&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mixte-groupe2",
                 "title": "Mixte - Groupe 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5704&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5704&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "privatiste-groupe1",
                 "title": "Privatiste - Groupe 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2599&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2599&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "privatiste-groupe2",
                 "title": "Privatiste - Groupe 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2718&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2718&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "privatiste-groupe3",
                 "title": "Privatiste - Groupe 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5128&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5128&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "publiciste-groupe1",
                 "title": "Publiciste - Groupe 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5966&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5966&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "publiciste-groupe2",
                 "title": "Publiciste - Groupe 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1841&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1841&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -2573,177 +2573,177 @@
               {
                 "id": "a",
                 "title": "A",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7271&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7271&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "b",
                 "title": "B",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4603&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4603&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "c",
                 "title": "C",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7275&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7275&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "d",
                 "title": "D",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2325&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2325&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "e",
                 "title": "E",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7272&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7272&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "f",
                 "title": "F",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1538&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1538&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g",
                 "title": "G",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5026&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5026&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "h",
                 "title": "H",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5062&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5062&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "poui-si",
                 "title": "P OUI-SI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2823&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2823&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "qoui-si",
                 "title": "Q OUI-SI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2824&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2824&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "roui-si",
                 "title": "R OUI-SI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2832&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2832&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "soui-si",
                 "title": "S OUI-SI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4055&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4055&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "u",
                 "title": "U",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1463&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1463&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "v",
                 "title": "V",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1512&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1512&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "w",
                 "title": "W",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7273&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7273&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "x",
                 "title": "X",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7274&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7274&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "y",
                 "title": "Y",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=382&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=382&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "z",
                 "title": "Z",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4436&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4436&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "13tpsl1",
                 "title": "1/3 Tps L1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4298&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4298&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag1",
                 "title": "AG1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4430&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4430&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag2",
                 "title": "AG2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4428&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4428&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag3",
                 "title": "AG3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4427&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4427&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag4",
                 "title": "AG4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4425&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4425&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag5",
                 "title": "AG5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4423&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4423&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag6",
                 "title": "AG6",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4422&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4422&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag7",
                 "title": "AG7",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4420&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4420&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag8",
                 "title": "AG8",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4418&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4418&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "all3ecol1",
                 "title": "ALL3 ECO L1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6319&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6319&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "all1ecol1",
                 "title": "ALL 1 ECO L1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4414&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4414&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "all2ecol1",
                 "title": "ALL 2 ECO L1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6595&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6595&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "breton",
                 "title": "BRETON",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5197&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5197&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp1",
                 "title": "ESP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4410&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4410&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp2",
                 "title": "ESP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4412&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4412&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp3",
                 "title": "ESP3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2875&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2875&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "optionuec",
                 "title": "OPTION UEC",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4416&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4416&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2754,167 +2754,167 @@
               {
                 "id": "a",
                 "title": "A",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4373&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4373&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "b",
                 "title": "B",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4372&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4372&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "c",
                 "title": "C",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4337&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4337&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "d",
                 "title": "D",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3734&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3734&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "e",
                 "title": "E",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4429&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4429&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "f",
                 "title": "F",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1487&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1487&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g",
                 "title": "G",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5180&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5180&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "h",
                 "title": "H",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=437&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=437&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "i",
                 "title": "I",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=703&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=703&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "j",
                 "title": "J",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7828&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7828&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "k",
                 "title": "K",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7829&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7829&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l",
                 "title": "L",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7824&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7824&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m",
                 "title": "M",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7825&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7825&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "n",
                 "title": "N",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7826&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7826&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "o",
                 "title": "O",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7827&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7827&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "p",
                 "title": "P",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2135&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2135&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "v",
                 "title": "V",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5987&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5987&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "w",
                 "title": "W",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4306&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4306&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "x",
                 "title": "X",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5496&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5496&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "y",
                 "title": "Y",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5323&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5323&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "z",
                 "title": "Z",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6521&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6521&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "all1",
                 "title": "ALL 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4448&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4448&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp1",
                 "title": "ESP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1482&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1482&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp2",
                 "title": "ESP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1483&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1483&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp3",
                 "title": "ESP3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7962&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7962&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag1",
                 "title": "AG1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4369&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4369&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag2",
                 "title": "AG2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4368&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4368&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag3",
                 "title": "AG3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4366&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4366&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag4",
                 "title": "AG4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=745&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=745&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag5",
                 "title": "AG5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=746&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=746&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag6",
                 "title": "AG6",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1592&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1592&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag7",
                 "title": "AG7",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1594&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1594&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "optionuec",
                 "title": "OPTION UEC",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2133&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2133&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -2925,97 +2925,97 @@
               {
                 "id": "aoddmv",
                 "title": "AO DD MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7848&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7848&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "aohiemv",
                 "title": "AO HIE MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4479&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4479&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ba",
                 "title": "BA",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6565&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6565&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g1mv",
                 "title": "G1 MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=638&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=638&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g2mv",
                 "title": "G2 MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=639&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=639&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g3mv",
                 "title": "G3 MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=657&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=657&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gamv",
                 "title": "GA MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=524&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=524&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gbmv",
                 "title": "GB MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=603&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=603&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mpr1",
                 "title": "MPR1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1661&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1661&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mpr2",
                 "title": "MPR2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4327&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4327&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mv1",
                 "title": "MV1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4336&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4336&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mv2",
                 "title": "MV2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4340&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4340&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mv3",
                 "title": "MV3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4341&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4341&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mva",
                 "title": "MVA",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=354&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=354&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "mvb",
                 "title": "MVB",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=404&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=404&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "alll3mv",
                 "title": "ALL L3MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1100&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1100&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp1mv",
                 "title": "ESP1 MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1009&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1009&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp2mv",
                 "title": "ESP2 MV",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6958&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6958&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "groupespromo2",
                 "title": "Groupes promo /2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=517&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=517&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -3026,47 +3026,47 @@
               {
                 "id": "aoddcf",
                 "title": "AO DD CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4797&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4797&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "aohiecf",
                 "title": "AO HIE CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1907&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1907&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g1cf",
                 "title": "G1 CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1329&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1329&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g2cf",
                 "title": "G2 CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1331&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1331&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "g3cf",
                 "title": "G3 CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1337&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1337&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gacf",
                 "title": "GA CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=661&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=661&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gbcf",
                 "title": "GB CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1108&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1108&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "alll3cf",
                 "title": "ALL L3CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1368&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1368&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "espcf",
                 "title": "ESP CF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5974&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5974&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -3077,172 +3077,172 @@
               {
                 "id": "13tps",
                 "title": "1/3 tps",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6322&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6322&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag1",
                 "title": "AG1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4387&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4387&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag2",
                 "title": "AG2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4393&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4393&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag3",
                 "title": "AG3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4394&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4394&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag4",
                 "title": "AG4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4437&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4437&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag5",
                 "title": "AG5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7804&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7804&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gdpi",
                 "title": "G DPI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5449&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5449&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gdpi1",
                 "title": "G DPI1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4667&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4667&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gdpi2",
                 "title": "G DPI2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4718&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4718&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ges",
                 "title": "G ES",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5493&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5493&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ggpa",
                 "title": "G GPA",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5477&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5477&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ggpa1",
                 "title": "G GPA1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2711&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2711&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ggpa2",
                 "title": "G GPA2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3684&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3684&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ghpe",
                 "title": "G HPE",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5480&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5480&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gmath",
                 "title": "G MATH",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5478&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5478&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gmath1",
                 "title": "G MATH1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4719&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4719&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gmath2",
                 "title": "G MATH2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4720&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4720&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gmbf",
                 "title": "G MBF",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5483&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5483&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "gthe",
                 "title": "G THE",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5488&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5488&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "v",
                 "title": "V",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5562&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5562&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "w",
                 "title": "W",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5563&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5563&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "x",
                 "title": "X",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5568&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5568&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "alll3ea",
                 "title": "ALL (L3 EA)",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4903&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4903&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp1",
                 "title": "ESP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4876&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4876&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp2",
                 "title": "ESP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7805&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7805&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "es1",
                 "title": "ES 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4637&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4637&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "es2",
                 "title": "ES 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4644&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4644&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "es3",
                 "title": "ES 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4645&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4645&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "hpe1",
                 "title": "HPE 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4650&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4650&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "hpe2",
                 "title": "HPE 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4652&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4652&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "hpe3",
                 "title": "HPE 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4653&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4653&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "the1",
                 "title": "THE 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4655&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4655&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "the2",
                 "title": "THE 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4656&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4656&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "the3",
                 "title": "THE 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4657&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4657&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -3253,152 +3253,152 @@
               {
                 "id": "13tps",
                 "title": "1/3 Tps",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4343&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4343&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "a1",
                 "title": "A1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4312&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4312&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "a2",
                 "title": "A2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1307&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1307&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "b1",
                 "title": "B1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4173&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4173&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "b2",
                 "title": "B2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1517&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1517&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "c1",
                 "title": "C1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3786&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3786&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "c2",
                 "title": "C2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1936&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1936&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "d",
                 "title": "D",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=200&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=200&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "du",
                 "title": "DU",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=335&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=335&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "e",
                 "title": "E",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=743&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=743&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egodpa1",
                 "title": "EGO DPA1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3664&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3664&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egodpa2",
                 "title": "EGO DPA2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2129&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2129&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egodpb1",
                 "title": "EGO DPB1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4569&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4569&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egodpb2",
                 "title": "EGO DPB2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1627&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1627&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egogpa1",
                 "title": "EGO GPA1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=185&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=185&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egogpa2",
                 "title": "EGO GPA2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2121&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2121&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egombfa1",
                 "title": "EGO MBF A1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=170&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=170&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egombfa2",
                 "title": "EGO MBF A2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5703&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5703&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egombfb1",
                 "title": "EGO MBF B1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7801&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7801&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "egombfb2",
                 "title": "EGO MBF B2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5138&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5138&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag1",
                 "title": "AG1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4317&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4317&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag2",
                 "title": "AG2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4388&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4388&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag3",
                 "title": "AG3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=889&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=889&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag4",
                 "title": "AG4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6136&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6136&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ag5",
                 "title": "AG5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7802&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7802&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "alll3ego",
                 "title": "ALL (L3 EGO)",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4316&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4316&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp1",
                 "title": "ESP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4315&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4315&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "esp2",
                 "title": "ESP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7803&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7803&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ges36",
                 "title": "G ES (36)",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5266&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5266&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ghpe",
                 "title": "G HPE",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5257&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5257&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -4012,47 +4012,47 @@
               {
                 "id": "l1-cmi-sd",
                 "title": "L1-CMI-SD",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7155&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7155&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-cupge",
                 "title": "L1-CUPGE",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3669&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3669&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mmi_ip",
                 "title": "L1-MMI_IP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4529&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4529&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mmi_mp",
                 "title": "L1-MMI_MP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4292&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4292&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mmi_im",
                 "title": "L1-MmI_IM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1910&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1910&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mmi_im",
                 "title": "L1-MmI_IM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4080&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4080&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mmi_ip",
                 "title": "L1-MmI_IP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3666&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3666&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mmi_mp",
                 "title": "L1-MmI_MP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3502&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3502&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-parcoursspecialise",
                 "title": "L1-parcours spécialisé",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2476&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2476&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4063,42 +4063,42 @@
               {
                 "id": "l2-cmi",
                 "title": "L2-CMI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3660&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3660&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-cupge_i",
                 "title": "L2-CUPGE_I",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4783&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4783&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-cupge_ms",
                 "title": "L2-CUPGE_MS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5344&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5344&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-info-phy",
                 "title": "L2-INFO-PHY",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3038&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3038&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-info-stat",
                 "title": "L2-INFO-STAT",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5419&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5419&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-math-info",
                 "title": "L2-MATH-INFO",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2896&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2896&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-math-phy",
                 "title": "L2-MATH-PHY",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2867&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2867&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-math-stat",
                 "title": "L2-MATH-STAT",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4118&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4118&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4109,42 +4109,42 @@
               {
                 "id": "l3-cmi",
                 "title": "L3-CMI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2434&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2434&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-info-1",
                 "title": "L3-INFO-1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=427&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=427&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-info-2",
                 "title": "L3-INFO-2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4796&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4796&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-info-3",
                 "title": "L3-INFO-3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4389&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4389&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-info-4",
                 "title": "L3-INFO-4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4434&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4434&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-math",
                 "title": "L3-MATH",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2022&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2022&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-stat-1",
                 "title": "L3-STAT-1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4545&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4545&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-stat-2",
                 "title": "L3-STAT-2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2118&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2118&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4155,27 +4155,27 @@
               {
                 "id": "m1-cmi",
                 "title": "M1-CMI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7862&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7862&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-info_1-aidn",
                 "title": "M1-INFO_1-AIDN",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4807&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4807&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-info_2-saim",
                 "title": "M1-INFO_2-SAIM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2625&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2625&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-stat_1",
                 "title": "M1-STAT_1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1397&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1397&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-stat_2",
                 "title": "M1-STAT_2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2910&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2910&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4186,32 +4186,32 @@
               {
                 "id": "m2-cmi",
                 "title": "M2-CMI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2817&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2817&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-info-aidn-1",
                 "title": "M2-INFO-AIDN-1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4778&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4778&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-info-aidn-2",
                 "title": "M2-INFO-AIDN-2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7857&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7857&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-info-saim",
                 "title": "M2-INFO-SAIM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=775&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=775&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-stat-dsms1",
                 "title": "M2-STAT-DSMS1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=830&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=830&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-stat-dsms2",
                 "title": "M2-STAT-DSMS2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6145&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6145&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -4228,82 +4228,82 @@
               {
                 "id": "ajacl1-l2i",
                 "title": "AJAC L1-L2 I",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2557&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2557&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ajacl1-l2ii",
                 "title": "AJAC L1-L2 II",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9170&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9170&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-cmi-i",
                 "title": "L1-CMI-I",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9166&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9166&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-cupge_p",
                 "title": "L1-CUPGE_P",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1767&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1767&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-cupge_s",
                 "title": "L1-CUPGE_S",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1764&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1764&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-las",
                 "title": "L1-LAS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6466&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6466&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mie_is",
                 "title": "L1-MIE_IS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1306&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1306&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mie_is-2",
                 "title": "L1-MIE_IS-2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9167&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9167&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mie_ms",
                 "title": "L1-MIE_MS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1321&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1321&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mip_ip",
                 "title": "L1-MIP_IP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2287&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2287&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mip_is",
                 "title": "L1-MIP_IS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2559&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2559&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mip_mi",
                 "title": "L1-MIP_MI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2346&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2346&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mip_mp",
                 "title": "L1-MIP_MP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1316&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1316&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mip_ms",
                 "title": "L1-MIP_MS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1317&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1317&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-mip_ms-2",
                 "title": "L1-MIP_MS-2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9168&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=9168&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1-parcoursspecialise",
                 "title": "L1-parcours spécialisé",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6571&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6571&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4314,47 +4314,47 @@
               {
                 "id": "l2-cmi",
                 "title": "L2-CMI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2556&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2556&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-cupge_info",
                 "title": "L2-CUPGE_INFO",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5895&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5895&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-cupge_math",
                 "title": "L2-CUPGE_MATH",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2384&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2384&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-cupge_stat",
                 "title": "L2-CUPGE_STAT",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4994&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4994&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-info-1",
                 "title": "L2-INFO-1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4675&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4675&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-info-2",
                 "title": "L2-INFO-2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2353&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2353&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-math",
                 "title": "L2-MATH",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4566&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4566&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-stat_info",
                 "title": "L2-STAT_INFO",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2672&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2672&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2-stat_math",
                 "title": "L2-STAT_MATH",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6514&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6514&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4365,42 +4365,42 @@
               {
                 "id": "cmi-is",
                 "title": "CMI-IS",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4163&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4163&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2info_1",
                 "title": "L3-2INFO_1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2234&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2234&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2info_2",
                 "title": "L3-2INFO_2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6555&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6555&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2info_3",
                 "title": "L3-2INFO_3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2544&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2544&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2info_4",
                 "title": "L3-2INFO_4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2615&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2615&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2math",
                 "title": "L3-2MATH",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=732&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=732&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2stat_1",
                 "title": "L3-2STAT_1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2722&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2722&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-2stat_2",
                 "title": "L3-2STAT_2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7094&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7094&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4411,27 +4411,27 @@
               {
                 "id": "m1-cmi-s",
                 "title": "M1-CMI-S",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1312&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1312&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-info_1-aidn",
                 "title": "M1-INFO_1-AIDN",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5884&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5884&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-info_2-saim",
                 "title": "M1-INFO_2-SAIM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4714&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4714&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-stat_1",
                 "title": "M1-STAT_1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5861&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5861&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-stat_2",
                 "title": "M1-STAT_2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1766&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1766&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -4458,32 +4458,32 @@
                   {
                     "id": "bp1a",
                     "title": "1a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2039&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2039&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "bp2b",
                     "title": "2b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=990&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=990&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "bp3a",
                     "title": "3a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1029&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1029&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "bp4b",
                     "title": "4b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=844&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=844&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "bp5a",
                     "title": "5a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=920&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=920&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "bp6b",
                     "title": "6b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8591&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8591&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4494,57 +4494,57 @@
                   {
                     "id": "eb10b",
                     "title": "10b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8593&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8593&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb11a",
                     "title": "11a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8594&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8594&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb1a",
                     "title": "1a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2029&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2029&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb2b",
                     "title": "2b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1672&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1672&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb3a",
                     "title": "3a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2056&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2056&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb4b",
                     "title": "4b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2070&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2070&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb5a",
                     "title": "5a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=998&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=998&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb6b",
                     "title": "6b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1221&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1221&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb7a",
                     "title": "7a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7863&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7863&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb8b",
                     "title": "8b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3739&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3739&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eb9a",
                     "title": "9a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8592&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8592&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4555,32 +4555,32 @@
                   {
                     "id": "eg1a",
                     "title": "1a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2137&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2137&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eg2b",
                     "title": "2b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2218&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2218&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eg3a",
                     "title": "3a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=787&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=787&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eg4b",
                     "title": "4b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1152&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1152&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eg5a",
                     "title": "5a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7836&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7836&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "eg6b",
                     "title": "6b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8595&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8595&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4591,19 +4591,19 @@
                   {
                     "id": "gp1a",
                     "title": "GP1a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2010&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2010&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "gp2b",
                     "title": "GP2b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=997&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=997&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
               {
                 "id": "autre",
                 "title": "Autre",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7865&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7865&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4614,12 +4614,12 @@
               {
                 "id": "l1sestp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=636&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=636&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l1sestp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6702&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6702&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4634,12 +4634,12 @@
                   {
                     "id": "a_1amth1106-phy1112-mph1102-mth1107-phy1113-chi1104",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=795&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=795&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_1amth1106-phy1112-mph1102-mth1107-phy1113-chi1104",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1633&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1633&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4650,12 +4650,12 @@
                   {
                     "id": "a_1bmth1106-phy1112-mph1102-mth1107-phy1113-inf1109",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5381&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5381&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_1bmth1106-phy1112-mph1102-mth1107-phy1113-inf1109",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5408&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5408&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4666,12 +4666,12 @@
                   {
                     "id": "a_1cmth1106-phy1112-mph1102-mth1107-phy1113-glg1104",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7078&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7078&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_1cmth1106-phy1112-mph1102-mth1107-phy1113-glg1104",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7143&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7143&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4682,12 +4682,12 @@
                   {
                     "id": "a_2amth1106-phy1112-chi1104-mth1107-phy1113",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7217&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7217&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_2amth1106-phy1112-chi1104-mth1107-phy1113",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7218&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7218&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4698,12 +4698,12 @@
                   {
                     "id": "a_2bmth1106-phy1112-inf1109-mth1107-phy1113",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7220&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7220&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_2bmth1106-phy1112-inf1109-mth1107-phy1113",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7222&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7222&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4714,12 +4714,12 @@
                   {
                     "id": "a_2cmth1106-phy1112-glg1104-mth1107-phy1113",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7190&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7190&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_2cmth1106-phy1112-glg1104-mth1107-phy1113",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7191&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7191&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4730,12 +4730,12 @@
                   {
                     "id": "a_31mth1106-phy1112-inf1109-mth1107-inf1107",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7225&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7225&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_31mth1106-phy1112-inf1109-mth1107-inf1107",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7226&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7226&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4746,12 +4746,12 @@
                   {
                     "id": "a_32mth1106-phy1112-inf1109-mth1107-inf1107",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7230&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7230&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_32mth1106-phy1112-inf1109-mth1107-inf1107",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7228&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7228&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -4768,12 +4768,12 @@
                   {
                     "id": "a_41mth1106-scn1101-inf1109-inf1107-phy1113",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7233&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7233&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_41mth1106-scn1101-inf1109-inf1107-phy1113",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7235&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7235&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4784,12 +4784,12 @@
                   {
                     "id": "a_42mth1106-scn1101-inf1109-inf1107-phy1113",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7240&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7240&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_42mth1106-scn1101-inf1109-inf1107-phy1113",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7241&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7241&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4800,12 +4800,12 @@
                   {
                     "id": "a_43mth1106-scn1101-inf1109-inf1107-phy1113",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7243&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7243&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "b_43mth1106-scn1101-inf1109-inf1107-phy1113",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7246&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7246&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -4826,12 +4826,12 @@
                       {
                         "id": "a_61mth1106-sdi1102-chi1104-mth1107-sdi1101-uepei",
                         "title": "Groupe A",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7276&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7276&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       },
                       {
                         "id": "b_61mth1106-sdi1102-chi1104-mth1107-sdi1101-uepei",
                         "title": "Groupe B",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7277&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7277&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       }
                     ]
                   },
@@ -4842,12 +4842,12 @@
                       {
                         "id": "a_62mth1106-sdi1102-chi1104-mth1107-sdi1101-uepei",
                         "title": "Groupe A",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7279&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7279&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       },
                       {
                         "id": "b_62mth1106-sdi1102-chi1104-mth1107-sdi1101-uepei",
                         "title": "Groupe B",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7280&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7280&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       }
                     ]
                   }
@@ -4864,12 +4864,12 @@
                       {
                         "id": "a_61-peil1mth1206-sdi1202-inf1209-mtx1201-sdi1201-uepeis2",
                         "title": "Groupe A",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6629&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6629&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       },
                       {
                         "id": "b_61-peil1mth1206-sdi1202-inf1209-mtx1201-sdi1201-uepeis2",
                         "title": "Groupe B",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8092&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8092&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       }
                     ]
                   },
@@ -4880,12 +4880,12 @@
                       {
                         "id": "a_62-peil1mth1206-sdi1202-inf1209-mtx1201-sdi1201-uepeis2",
                         "title": "Groupe A",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6619&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6619&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       },
                       {
                         "id": "b_62-peil1mth1206-sdi1202-inf1209-mtx1201-sdi1201-uepeis2",
                         "title": "Groupe B",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8091&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8091&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       }
                     ]
                   }
@@ -4904,12 +4904,12 @@
                   {
                     "id": "g1",
                     "title": "Groupe 1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4077&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4077&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "g2",
                     "title": "Groupe 2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4039&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4039&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -4920,12 +4920,12 @@
                   {
                     "id": "g1",
                     "title": "Groupe 1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6629&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6629&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "g2",
                     "title": "Groupe 2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6619&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6619&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -4944,27 +4944,27 @@
               {
                 "id": "l2sesgr1",
                 "title": "Gr1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1569&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1569&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2sesgr2",
                 "title": "Gr2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1570&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1570&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2sesgr3",
                 "title": "Gr3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2472&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2472&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2sesme",
                 "title": "ME",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5119&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5119&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2sespc",
                 "title": "PC",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5111&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5111&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -4975,92 +4975,92 @@
               {
                 "id": "abc1a",
                 "title": "ABC1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7610&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7610&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "abc2b",
                 "title": "ABC2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7611&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7611&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "abc3a",
                 "title": "ABC3a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4813&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4813&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "abd1a",
                 "title": "ABD1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7612&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7612&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "abd2b",
                 "title": "ABD2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1290&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1290&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "abe1a",
                 "title": "ABE1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7613&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7613&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "abe2b",
                 "title": "ABE2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3618&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3618&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "acd1a",
                 "title": "ACD1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7618&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7618&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "acd2b",
                 "title": "ACD2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7621&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7621&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ace1a",
                 "title": "ACE1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7623&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7623&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "ace2b",
                 "title": "ACE2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3668&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3668&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "bcd1a",
                 "title": "BCD1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7614&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7614&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "bcd2b",
                 "title": "BCD2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7615&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7615&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "bcd3a",
                 "title": "BCD3a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7616&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7616&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "bce1a",
                 "title": "BCE1a",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4464&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4464&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "bce2b",
                 "title": "BCE2b",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7622&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7622&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "autre",
                 "title": "autre",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7617&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7617&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "autres",
                 "title": "autres",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7620&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7620&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5071,7 +5071,7 @@
               {
                 "id": "cc13temps",
                 "title": "CC 1/3 temps",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6819&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6819&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l2peisemestre3",
@@ -5080,12 +5080,12 @@
                   {
                     "id": "g1",
                     "title": "Groupe 1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1745&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1745&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "g2",
                     "title": "Groupe 2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1980&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1980&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5096,12 +5096,12 @@
                   {
                     "id": "g1",
                     "title": "Groupe 1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7420&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7420&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "g2",
                     "title": "Groupe 2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7421&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7421&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5120,12 +5120,12 @@
               {
                 "id": "biosantetp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1901&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1901&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "biosantetp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2223&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2223&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5136,12 +5136,12 @@
               {
                 "id": "biotechtp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1920&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1920&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "biotechtp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1945&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1945&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5152,12 +5152,12 @@
               {
                 "id": "tacbtp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1894&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1894&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tacbtp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1895&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1895&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5168,12 +5168,12 @@
               {
                 "id": "l3sestp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5417&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5417&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3sestp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5421&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5421&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5184,22 +5184,22 @@
               {
                 "id": "l3ens-spipe",
                 "title": "ENS-SPI PE",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1669&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1669&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3ens-spisi",
                 "title": "ENS-SPI SI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=187&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=187&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3ens-svtpe",
                 "title": "ENS-SVT PE",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1708&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1708&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3ens-svtsi",
                 "title": "ENS-SVT SI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1871&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1871&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5210,12 +5210,12 @@
               {
                 "id": "tacbprotp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1896&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1896&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "tacbprotp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1282&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1282&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5226,12 +5226,12 @@
               {
                 "id": "l3-pro-nautismegr1",
                 "title": "L3-pro-NAUTISME gr 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1210&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1210&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-pro-nautismegr2",
                 "title": "L3-pro-NAUTISME gr 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1868&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1868&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5242,12 +5242,12 @@
               {
                 "id": "l3-pro-emec1",
                 "title": "L3-pro-EMEC 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1202&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1202&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "l3-pro-emec2",
                 "title": "L3-pro-EMEC 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=717&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=717&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           }
@@ -5264,7 +5264,7 @@
               {
                 "id": "dui3dsante",
                 "title": "I3D Santé",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6387&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6387&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5275,7 +5275,7 @@
               {
                 "id": "i3dmci",
                 "title": "I3D MCI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6480&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6480&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5286,7 +5286,7 @@
               {
                 "id": "cpeml",
                 "title": "CPEM L",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4951&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4951&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5297,19 +5297,19 @@
               {
                 "id": "dui3dsante",
                 "title": "DU I3D Santé",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6387&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6387&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "i3dmci",
                 "title": "I3D MCI",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6480&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6480&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
           {
             "id": "cpeml",
             "title": "CPEM L",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4951&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4951&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           }
         ]
       },
@@ -5328,17 +5328,17 @@
                   {
                     "id": "s7grouperoscoff",
                     "title": "Groupe Roscoff",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5349&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5349&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s7m1bio-bmbgpa",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=450&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=450&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s7m1bio-bmbgpb",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2880&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2880&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5349,42 +5349,42 @@
                   {
                     "id": "s8grouperoscoff",
                     "title": "Groupe Roscoff",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5025&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5025&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-bmbgpa",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5030&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5030&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-bmbgpb",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5049&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5049&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-bmbtp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4769&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4769&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-bmbtp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5007&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5007&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-3mbtp3",
                     "title": "TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5012&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5012&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-bmbtp4",
                     "title": "TP4",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5016&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5016&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "s8m1bio-bmbtp5",
                     "title": "TP5",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5368&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5368&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5397,12 +5397,12 @@
               {
                 "id": "m1csse-alternants",
                 "title": "Alternants",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1893&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1893&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1csse-nonalternants",
                 "title": "Non Alternants",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7780&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=7780&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5417,12 +5417,12 @@
                   {
                     "id": "m1-mtx1a",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=610&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=610&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-mtx1b",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1947&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1947&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5433,12 +5433,12 @@
                   {
                     "id": "m1-mtx2a",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1975&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1975&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-mtx2b",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1992&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1992&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5451,17 +5451,17 @@
               {
                 "id": "m1-gmm-tp1",
                 "title": "TP1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=683&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=683&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-gmm-tp2",
                 "title": "TP2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=684&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=684&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m1-gmm-tp3",
                 "title": "TP3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=346&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=346&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5476,12 +5476,12 @@
                   {
                     "id": "m1-gcamp;mp-tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=491&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=491&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-gcamp;mp-tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=493&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=493&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5492,22 +5492,22 @@
                   {
                     "id": "m1-gcamp;mp-tp1",
                     "title": "TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1252&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1252&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-gcamp;mp-tp2",
                     "title": "TP2",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1278&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1278&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-gcamp;mp-tp3",
                     "title": "TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=494&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=494&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-gcamp;mp-tp4",
                     "title": "TP4",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=495&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=495&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5524,12 +5524,12 @@
                   {
                     "id": "m1-ene1a",
                     "title": "M1 - ENE 1a",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2062&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2062&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-ene1b",
                     "title": "M1- ENE 1b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2063&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2063&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5540,12 +5540,12 @@
                   {
                     "id": "m1-ene2a",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2100&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2100&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m1-ene2b",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2114&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2114&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5554,17 +5554,17 @@
           {
             "id": "m1eiihispano",
             "title": "M1 EII Hispano",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=92&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=92&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "m1sesi",
             "title": "M1 SESI",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1880&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1880&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "m1-opamp;pi",
             "title": "M1-OP&PI",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4834&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4834&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           }
         ]
       },
@@ -5579,12 +5579,12 @@
               {
                 "id": "m2isc-csse-alternants",
                 "title": "Alternants",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=688&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=688&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2isc-csse-nonalternants",
                 "title": "Non Alternants",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1858&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1858&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5595,12 +5595,12 @@
               {
                 "id": "m2-opamp;pi-alt",
                 "title": "Alternant",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=496&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=496&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-opamp;pi-spe",
                 "title": "Spé",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1296&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1296&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5611,37 +5611,37 @@
               {
                 "id": "m2-bio-bmb-1",
                 "title": "Groupe 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=320&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=320&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-bio-bmb-2",
                 "title": "Groupe 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=915&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=915&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-bio-bmb-3",
                 "title": "Groupe 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2727&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2727&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-bio-bmb-4",
                 "title": "Groupe 4",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2506&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2506&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-bio-bmb-5",
                 "title": "Groupe 5",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2741&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=2741&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-bio-bmb-bam",
                 "title": "BAM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1585&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1585&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2-bio-bmb-biomacrom",
                 "title": "BIOMACROM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1586&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1586&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5656,12 +5656,12 @@
                   {
                     "id": "m2-ene1a_p",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=204&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=204&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m2-ene1b_p",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=205&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=205&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5672,24 +5672,24 @@
                   {
                     "id": "m2-ene2a_p",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=206&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=206&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m2-ene2b_p",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=207&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=207&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
               {
                 "id": "m2_ene_recherche",
                 "title": "Recherche",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1899&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1899&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2eneagstelasertinean",
                 "title": "AG Stela Sertinean",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4960&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4960&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5704,7 +5704,7 @@
                   {
                     "id": "tp1",
                     "title": "Esp. TP1",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4608&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4608&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2a",
@@ -5713,12 +5713,12 @@
                       {
                         "id": "m2gcpalltp2a",
                         "title": "All. TP2a",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4786&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4786&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       },
                       {
                         "id": "m2gcpesptp2a",
                         "title": "Esp. TP2a",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4868&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4868&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       }
                     ]
                   }
@@ -5731,12 +5731,12 @@
                   {
                     "id": "tp2b",
                     "title": "Esp. TP2b",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4861&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4861&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp3",
                     "title": "Esp. TP3",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4867&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4867&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5757,29 +5757,29 @@
                       {
                         "id": "m2gcaalltp1",
                         "title": "All. TP1",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5854&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5854&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       },
                       {
                         "id": "m2gcaesptp1",
                         "title": "Esp. TP1",
-                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5852&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                        "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5852&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                       }
                     ]
                   },
                   {
                     "id": "tp2aaltesp",
                     "title": "TP2a Alt Esp",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8600&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=8600&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "tp2aaltfle",
                     "title": "TP2a Alt FLE",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3002&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3002&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m2gcaltpresentiel",
                     "title": "M2GC Alt Présentiel",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3573&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3573&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5792,32 +5792,32 @@
               {
                 "id": "m2gm-double",
                 "title": "Double",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1870&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1870&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2gm-pur",
                 "title": "Pur",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1864&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1864&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2gmtp",
                 "title": "TP",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=769&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=769&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2gmtp_1",
                 "title": "TP 1",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=679&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=679&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2gmtp_2",
                 "title": "TP 2",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1564&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1564&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               },
               {
                 "id": "m2gmtp_3",
                 "title": "TP 3",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=899&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=899&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
@@ -5832,12 +5832,12 @@
                   {
                     "id": "m2-ecpc-1a_p",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=251&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=251&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m2-ecpc-1b_p",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4922&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4922&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
@@ -5848,12 +5848,12 @@
                   {
                     "id": "m2-ecpc-2a_p",
                     "title": "Groupe A",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1760&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1760&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m2-ecpc-2b_p",
                     "title": "Groupe B",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4924&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=4924&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               }
@@ -5870,46 +5870,46 @@
                   {
                     "id": "m2gcrall",
                     "title": "All.",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5215&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5215&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   },
                   {
                     "id": "m2gcresp",
                     "title": "Esp.",
-                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5717&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                    "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=5717&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
                   }
                 ]
               },
               {
                 "id": "m2r-gm",
                 "title": "M2R-GM",
-                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=792&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+                "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=792&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
               }
             ]
           },
           {
             "id": "m2-ec",
             "title": "M2-EC",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3540&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=3540&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "m2-eit",
             "title": "M2-EIT",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6007&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=6007&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "m2iscsesi",
             "title": "M2 ISC SESI",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=689&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=689&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "m2-i-mars",
             "title": "M2-I-Mars",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1731&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1731&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           },
           {
             "id": "m2-c'nano",
             "title": "M2-C'Nano",
-            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1814&projectId=4&calType=ical&firstDate={date-start}&lastDate={date-end}"
+            "url": "https://planning.univ-ubs.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=1814&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
           }
         ]
       }

--- a/assets/plannings.json
+++ b/assets/plannings.json
@@ -1456,8 +1456,8 @@
         "title": "CyberDéfense",
         "edts": [
           {
-            "id": "1ereannee",
-            "title": "1ère année",
+            "id": "3emeannee",
+            "title": "3ème année",
             "edts": [
               {
                 "id": "semestre5s5",
@@ -1534,8 +1534,8 @@
             ]
           },
           {
-            "id": "2emeannee",
-            "title": "2ème année",
+            "id": "4emeannee",
+            "title": "4ème année",
             "edts": [
               {
                 "id": "semestre7s7",
@@ -1612,8 +1612,8 @@
             ]
           },
           {
-            "id": "3emeannee",
-            "title": "3ème année",
+            "id": "5emeannee",
+            "title": "5ème année",
             "edts": [
               {
                 "id": "tp1",
@@ -1654,8 +1654,8 @@
         "title": "CyberLog",
         "edts": [
           {
-            "id": "1ereannee",
-            "title": "1ère année",
+            "id": "3emeannee",
+            "title": "3ème année",
             "edts": [
               {
                 "id": "semestre5s5",
@@ -1692,8 +1692,8 @@
             ]
           },
           {
-            "id": "2emeannee",
-            "title": "2ème année",
+            "id": "4emeannee",
+            "title": "4ème année",
             "edts": [
               {
                 "id": "semestre7s7",
@@ -1730,8 +1730,8 @@
             ]
           },
           {
-            "id": "3emeannee",
-            "title": "3ème année",
+            "id": "5emeannee",
+            "title": "5ème année",
             "edts": [
               {
                 "id": "tp1",
@@ -1752,8 +1752,8 @@
         "title": "CyberData",
         "edts": [
           {
-            "id": "1ereannee",
-            "title": "1ère année",
+            "id": "3emeannee",
+            "title": "3ème année",
             "edts": [
               {
                 "id": "semestre5s5",
@@ -1790,8 +1790,8 @@
             ]
           },
           {
-            "id": "2emeannee",
-            "title": "2ème année",
+            "id": "4emeannee",
+            "title": "4ème année",
             "edts": [
               {
                 "id": "semestre7s7",
@@ -1828,8 +1828,8 @@
             ]
           },
           {
-            "id": "3emeannee",
-            "title": "3ème année",
+            "id": "5emeannee",
+            "title": "5ème année",
             "edts": [
               {
                 "id": "semestre9s9",
@@ -1851,8 +1851,8 @@
         "title": "Génie Industriel",
         "edts": [
           {
-            "id": "1ereannee",
-            "title": "1ère année",
+            "id": "3emeannee",
+            "title": "3ème année",
             "edts": [
               {
                 "id": "semestre5s5",
@@ -1889,8 +1889,8 @@
             ]
           },
           {
-            "id": "2emeannee",
-            "title": "2ème année",
+            "id": "4emeannee",
+            "title": "4ème année",
             "edts": [
               {
                 "id": "semestre7s7",
@@ -1927,8 +1927,8 @@
             ]
           },
           {
-            "id": "3emeannee",
-            "title": "3ème année",
+            "id": "5emeannee",
+            "title": "5ème année",
             "edts": [
               {
                 "id": "m2oppi",
@@ -1954,8 +1954,8 @@
         "title": "Génie Civil",
         "edts": [
           {
-            "id": "1ereannee",
-            "title": "1ère année",
+            "id": "3emeannee",
+            "title": "3ème année",
             "edts": [
               {
                 "id": "semestre5s5",
@@ -1992,8 +1992,8 @@
             ]
           },
           {
-            "id": "2emeannee",
-            "title": "2ème année",
+            "id": "4emeannee",
+            "title": "4ème année",
             "edts": [
               {
                 "id": "semestre7s7",
@@ -2036,8 +2036,8 @@
         "title": "Mécatronique",
         "edts": [
           {
-            "id": "1ereannee",
-            "title": "1ère année",
+            "id": "3emeannee",
+            "title": "3ème année",
             "edts": [
               {
                 "id": "semestre5s5",
@@ -2074,8 +2074,8 @@
             ]
           },
           {
-            "id": "2emeannee",
-            "title": "2ème année",
+            "id": "4emeannee",
+            "title": "4ème année",
             "edts": [
               {
                 "id": "semestre7s7",
@@ -2112,8 +2112,8 @@
             ]
           },
           {
-            "id": "3emeannee",
-            "title": "3ème année",
+            "id": "5emeannee",
+            "title": "5ème année",
             "edts": [
               {
                 "id": "cpro",


### PR DESCRIPTION
Le 29/08/2023, le projectId de l'UBS de l'année 2023-2024 est passé de "4" à "1", suite à la supression par la DSI du projet pour l'année 2021-2022 sur ADE.

Plus : Change STID en DS  (Sciences des données), nouveau nom de la formation.