### PR TITLE
feat: rename favorite plannings

### DIFF
--- a/components/SelectPlanning.vue
+++ b/components/SelectPlanning.vue
@@ -559,8 +559,8 @@ export default {
       })
     },
     getNames () {
-      const favoritesIds = Object.keys(this.favorites)
-      const list = [...(favoritesIds || []), ...(this.groupFavorites || []).map(v => v.plannings).flat()]
+      const favoritesIds = Object.keys(this.favorites ?? {})
+      const list = [...favoritesIds, ...(this.groupFavorites || []).map(v => v.plannings).flat()]
       if (list.length) {
         this.$axios.$get('/api/v1/calendars/info', { params: { p: list.join(',') } }).then((data) => {
           this.planningNames = data

--- a/components/SelectPlanning.vue
+++ b/components/SelectPlanning.vue
@@ -63,7 +63,7 @@
                 autofocus
                 label="Nom du groupe"
                 :rules="favoriteGroupNameRules"
-                @keyup.enter="() => { if (isFavoriteGroupRulesOk) createFavoriteGroup }"
+                @keyup.enter="() => { if (isFavoriteGroupRulesOk) { createFavoriteGroup() } }"
               />
               <span v-if="localPlannings?.length > 1">{{ localPlannings?.length || 0 }} plannings seront ajoutés au groupe</span>
             </v-card-text>
@@ -189,7 +189,7 @@
                                   autofocus
                                   label="Nom du favori"
                                   :rules="favoriteNameRules"
-                                  @keyup.enter="() => { if (isFavoriteNameRulesOk) renameFavoriteGroup(groupFavorite) }"
+                                  @keyup.enter="() => { if (isFavoriteNameRulesOk) { renameFavoriteGroup(groupFavorite) } }"
                                 />
                               </v-card-text>
                               <v-card-actions>
@@ -261,7 +261,7 @@
                                   autofocus
                                   label="Nom du favori"
                                   :rules="favoriteNameRules"
-                                  @keyup.enter="() => { if (isFavoriteNameRulesOk) renameFavorite(favorite) }"
+                                  @keyup.enter="() => { if (isFavoriteNameRulesOk) { renameFavorite(favorite) } }"
                                 />
                               </v-card-text>
                               <v-card-actions>

--- a/components/SelectPlanning.vue
+++ b/components/SelectPlanning.vue
@@ -63,7 +63,7 @@
                 autofocus
                 label="Nom du groupe"
                 :rules="favoriteGroupNameRules"
-                @keyup.enter="createFavoriteGroup"
+                @keyup.enter="() => { if (isFavoriteGroupRulesOk) createFavoriteGroup }"
               />
               <span v-if="localPlannings?.length > 1">{{ localPlannings?.length || 0 }} plannings seront ajoutés au groupe</span>
             </v-card-text>
@@ -162,18 +162,61 @@
                         </v-list-item-subtitle>
                       </v-list-item-content>
                       <v-list-item-action>
-                        <v-btn
-                          small
-                          icon
-                          @click="deleteFavoriteGroup(i)"
-                        >
-                          <v-icon
-                            small
-                            color="red"
+                        <div>
+                          <v-menu
+                            v-model="favoriteRenameMenus[groupFavorite]"
+                            :close-on-content-click="false"
+                            offset-y
+                            left
                           >
-                            {{ mdiDelete }}
-                          </v-icon>
-                        </v-btn>
+                            <template #activator="{ on: menu, attrs }">
+                              <v-btn
+                                small
+                                icon
+                                v-bind="attrs"
+                                v-on="menu"
+                                @click="newFavoriteName = groupFavorite.name"
+                              >
+                                <v-icon small>
+                                  {{ mdiPencil }}
+                                </v-icon>
+                              </v-btn>
+                            </template>
+                            <v-card width="300">
+                              <v-card-text>
+                                <v-text-field
+                                  v-model="newFavoriteName"
+                                  autofocus
+                                  label="Nom du favori"
+                                  :rules="favoriteNameRules"
+                                  @keyup.enter="() => { if (isFavoriteNameRulesOk) renameFavoriteGroup(groupFavorite) }"
+                                />
+                              </v-card-text>
+                              <v-card-actions>
+                                <v-spacer />
+                                <v-btn
+                                  text
+                                  :disabled="!isFavoriteNameRulesOk"
+                                  @click="renameFavoriteGroup(groupFavorite)"
+                                >
+                                  Renommer
+                                </v-btn>
+                              </v-card-actions>
+                            </v-card>
+                          </v-menu>
+                          <v-btn
+                            small
+                            icon
+                            @click="deleteFavoriteGroup(i)"
+                          >
+                            <v-icon
+                              small
+                              color="red"
+                            >
+                              {{ mdiDelete }}
+                            </v-icon>
+                          </v-btn>
+                        </div>
                       </v-list-item-action>
                     </v-list-item>
 
@@ -581,6 +624,13 @@ export default {
       this.$cookies.set('favorites-names', this.favoritesNames, { maxAge: 2147483646 })
       this.newFavoriteName = ''
       this.favoriteRenameMenus[favorite] = false
+    },
+    renameFavoriteGroup (favoriteGroup) {
+      const index = this.groupFavorites.findIndex(v => v.name === favoriteGroup.name)
+      this.$set(this.groupFavorites[index], 'name', this.newFavoriteName)
+      this.$cookies.set('group-favorites', this.groupFavorites, { maxAge: 2147483646 })
+      this.newFavoriteName = ''
+      this.favoriteRenameMenus[favoriteGroup] = false
     },
     createFavoriteGroup () {
       if (!this.newFavoriteGroupName) return

--- a/components/SelectPlanning.vue
+++ b/components/SelectPlanning.vue
@@ -85,7 +85,15 @@
           @click="copyTextToClipboard()"
         >
           <v-icon>{{ mdiContentCopy }}</v-icon>
-        </v-btn><v-btn
+        </v-btn>
+        <v-btn
+          v-tooltip="'Reinitialiser la sélection'"
+          icon
+          @click="reset()"
+        >
+          <v-icon>{{ mdiRestore }}</v-icon>
+        </v-btn>
+        <v-btn
           icon
           @click="$emit('close')"
         >
@@ -104,14 +112,6 @@
         hide-details
         dense
       />
-      <v-btn
-        text
-        small
-        color="green"
-        @click="reset"
-      >
-        Réinitialiser
-      </v-btn>
       <div style="max-height: calc(90vh - 300px); overflow: auto;">
         <transition name="fade">
           <div
@@ -389,19 +389,20 @@
 
 <script>
 import {
-  mdiDelete,
-  mdiStarHalfFull,
-  mdiStar,
-  mdiStarOutline,
-  mdiClose,
-  mdiContentCopy,
   mdiCalendar,
-  mdiMenuDown,
-  mdiMinusBox,
-  mdiPencil,
   mdiCheckboxBlankOutline,
   mdiCheckboxMarked,
-  mdiFormatListGroup
+  mdiClose,
+  mdiContentCopy,
+  mdiDelete,
+  mdiFormatListGroup,
+  mdiMenuDown,
+  mdiMinusBox,
+  mdiStar,
+  mdiStarHalfFull,
+  mdiStarOutline,
+  mdiPencil,
+  mdiRestore
 } from '@mdi/js'
 
 export default {
@@ -422,19 +423,20 @@ export default {
   },
   data () {
     return {
-      mdiDelete,
+      mdiCalendar,
       mdiCheckboxBlankOutline,
       mdiCheckboxMarked,
-      mdiMinusBox,
-      mdiMenuDown,
-      mdiCalendar,
       mdiClose,
       mdiContentCopy,
-      mdiStarHalfFull,
-      mdiStar,
-      mdiStarOutline,
+      mdiDelete,
       mdiFormatListGroup,
+      mdiMenuDown,
+      mdiMinusBox,
+      mdiStar,
+      mdiStarHalfFull,
+      mdiStarOutline,
       mdiPencil,
+      mdiRestore,
 
       menuGroup: false,
 


### PR DESCRIPTION
When using the app on mobile, the default names for favorite plannings get truncated and are not very descriptive. This renaming feature allows users to give their favorites shorter, more meaningful names, improving the user experience on smaller screens.

- favorite card is flat instead of rounded to avoid an ugly border in dark theme
- we can rename favorite plannings (follows the same rules as planning groups)
- fix: hitting enter when creating a plannings group that doesn't follow the rules doesn't create it
- migrate favorites cookie to dictionary format : `{"id":"name"}`
- add a check to convert legacy favorite cookie to dictionary format
- split add and remove favorites in 2 separate functions + a toggle function
- moved the reset selection button from a text under the search bar to a button next to the others