### PR TITLE
add word boundary check to highlighting regex

### DIFF
--- a/server/util/utils.js
+++ b/server/util/utils.js
@@ -59,7 +59,7 @@ const getColor = (value, location, description, id, options = {}) => {
     return '#676767'
   } else if (/\bCM\b/.test(value) || value.toUpperCase().includes('AMPHI') || location.toUpperCase().includes('AMPHI')) {
     return options.customColor?.amphi || '#efd6d8'
-  } else if (/\bTP\b/.test(value) || value.includes('TDi') || value.trim().match(/\sG\d\.\d$/)) {
+  } else if (/\bTP\b/.test(value) || value.includes('TPi') || value.includes('TDi') || value.trim().match(/\sG\d\.\d$/)) {
     return options.customColor?.tp || '#bbe0ff'
   } else if ((/\bTD\b/.test(value) || location.includes('V-B') || value.trim().match(/\sG\d$/)) && !/^S\d\.\d\d/.test(value) && !/contr[ôo]le/i.test(value)) {
     return options.customColor?.td || '#d4fbcc'

--- a/server/util/utils.js
+++ b/server/util/utils.js
@@ -57,11 +57,11 @@ const checkHighlightTeacher = ({ description, id, value, location }) => {
 const getColor = (value, location, description, id, options = {}) => {
   if (options.highlightTeacher && checkHighlightTeacher({ description, id, value, location })) {
     return '#676767'
-  } else if (value.includes('CM') || value.toUpperCase().includes('AMPHI') || location.toUpperCase().includes('AMPHI')) {
+  } else if (/\bCM\b/.test(value) || value.toUpperCase().includes('AMPHI') || location.toUpperCase().includes('AMPHI')) {
     return options.customColor?.amphi || '#efd6d8'
-  } else if (value.includes('TP') || value.includes('TDi') || value.trim().match(/\sG\d\.\d$/)) {
+  } else if (/\bTP\b/.test(value) || value.includes('TDi') || value.trim().match(/\sG\d\.\d$/)) {
     return options.customColor?.tp || '#bbe0ff'
-  } else if ((value.includes('TD') || location.includes('V-B') || value.trim().match(/\sG\d$/)) && !/^S\d\.\d\d/.test(value) && !/contr[ôo]le/i.test(value)) {
+  } else if ((/\bTD\b/.test(value) || location.includes('V-B') || value.trim().match(/\sG\d$/)) && !/^S\d\.\d\d/.test(value) && !/contr[ôo]le/i.test(value)) {
     return options.customColor?.td || '#d4fbcc'
   } else {
     return options.customColor?.other || '#EDDD6E'


### PR DESCRIPTION
Cela corrige l'erreur ou "CMPL-TD" peut se trouver en couleur de CM.

N'hésite pas à me dire s'il y a des choses à améliorer, et merci pour le projet ^^

Avant: 
![image](https://github.com/user-attachments/assets/17187b6a-ecb7-44f5-a20d-f821bea525f9)

Après:
![image](https://github.com/user-attachments/assets/ca0a9920-18c2-4098-9f63-7cf995afee26)

