### PR TITLE
Ajout du M2 RSSI de l'ISTIC et fix url M2 CR

### DIFF
--- a/resources/plannings/istic.json
+++ b/resources/plannings/istic.json
@@ -2996,6 +2996,11 @@
         {
           "id": "isticmcr2",
           "title": "Master Cloud et Réseaux",
+          "url": "https://planning.univ-rennes1.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=18089&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
+        },
+        {
+          "id": "isticmrssi2",
+          "title": "Master RSSI (option mémoire)",
           "url": "https://planning.univ-rennes1.fr/jsp/custom/modules/plannings/anonymous_cal.jsp?resources=11685&projectId=1&calType=ical&firstDate={date-start}&lastDate={date-end}"
         },
         {


### PR DESCRIPTION
J'ai rajouté l'URL du master 2 RSSI et je me suis aperçu qu'il y avait une erreur avec l'URL du M2 Cloud et Réseaux, qui utilisait l'URL du M2 RSSI, j'ai donc mis l'URL du M2 CR Classique, à voir si c'est la bonne.