### PR TITLE
feat(api): implement range filtering for plannings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ postgres_data
 
 CLAUDE.md
 GEMINI.md
+/.vscode

--- a/apps/api/src/routes/plannings.ts
+++ b/apps/api/src/routes/plannings.ts
@@ -2,6 +2,7 @@ import { cleanedPlannings, flattenedPlannings } from '@api/plannings'
 import { getFailureReason, getFormattedEvents, resolveEvents } from '@api/utils/events'
 import { elysiaLogger } from '@api/utils/logger'
 import { markPlanningRefreshSuccess, requestPlanningRefresh, schedulePlanningBackupWrite } from '@api/utils/plannings-backup'
+import dayjs from 'dayjs'
 import { Elysia, t } from 'elysia'
 
 export default new Elysia({ prefix: '/plannings', tags: ['Plannings'] })
@@ -19,8 +20,30 @@ export default new Elysia({ prefix: '/plannings', tags: ['Plannings'] })
 
     if (query.events === 'true') {
       const onlyDb = query.onlyDb === 'true'
+      const from = query.from
+      const to = query.to
+      const hasRange = !!(from || to)
 
-      const resolveResult = await resolveEvents(planning, onlyDb)
+      if (hasRange && onlyDb) {
+        return status(400, { error: 'Range filtering is only supported for network-first calls' })
+      }
+
+      if (hasRange) {
+        const start = from ? dayjs(from) : (to ? dayjs(to).subtract(2, 'year') : dayjs().subtract(1, 'month'))
+        const end = to ? dayjs(to) : (from ? dayjs(from).add(2, 'year') : dayjs().add(2, 'year'))
+
+        if (!start.isValid() || !end.isValid()) {
+          return status(400, { error: 'Invalid range dates' })
+        }
+
+        if (end.diff(start, 'day') > 731) {
+          return status(400, { error: 'Range too large (max 2 years)' })
+        }
+      }
+
+      const range = hasRange ? { from, to } : undefined
+
+      const resolveResult = await resolveEvents(planning, onlyDb, range)
       const { events, source } = resolveResult
 
       // blocklist ?blocklist=string (comma-separated)
@@ -39,6 +62,7 @@ export default new Elysia({ prefix: '/plannings', tags: ['Plannings'] })
             blocklist,
             highlightTeacher,
             localeUtils,
+            range,
           })
         : null
 
@@ -58,7 +82,8 @@ export default new Elysia({ prefix: '/plannings', tags: ['Plannings'] })
       // Keep backups fresh when the UI hits the API directly:
       // - If we successfully fetched events from the network, write-through to DB asynchronously (no extra upstream fetch).
       // - If network failed (and onlyDb wasn't requested), enqueue a refresh retry with priority.
-      if (!onlyDb) {
+      // - SKIP if a custom range was requested (partial data shouldn't overwrite full backup).
+      if (!onlyDb && !hasRange) {
         if (source === 'network') {
           void markPlanningRefreshSuccess(planning.fullId).catch((error) => {
             elysiaLogger.warn('Failed to mark planning refresh success for {fullId}: {error}', { fullId, error })
@@ -79,11 +104,12 @@ export default new Elysia({ prefix: '/plannings', tags: ['Plannings'] })
         }
       }
 
-      elysiaLogger.info(`Serving events for planning {fullId} : {nbEvents} events, source: {source}, reason: {reason}, blocklist: {blocklist}, highlightTeacher: {highlightTeacher}`, {
+      elysiaLogger.info(`Serving events for planning {fullId} : {nbEvents} events, source: {source}, reason: {reason}, range: {range}, blocklist: {blocklist}, highlightTeacher: {highlightTeacher}`, {
         fullId,
         nbEvents,
         source,
         reason,
+        range,
         blocklist,
         highlightTeacher,
       })
@@ -109,6 +135,8 @@ export default new Elysia({ prefix: '/plannings', tags: ['Plannings'] })
     query: t.Object({
       events: t.Optional(t.String({ description: 'Set to "true" to include calendar events' })),
       onlyDb: t.Optional(t.String({ description: 'Set to "true" to only fetch from database (no network)' })),
+      from: t.Optional(t.String({ description: 'Start date for filtering (YYYY-MM-DD)' })),
+      to: t.Optional(t.String({ description: 'End date for filtering (YYYY-MM-DD)' })),
       blocklist: t.Optional(t.String({ description: 'Comma-separated list of keywords to filter out events' })),
       highlightTeacher: t.Optional(t.String({ description: 'Set to "true" to highlight teacher names' })),
       browserTimezone: t.Optional(t.String({ description: 'Browser timezone (fallback for x-timezone header)' })),

--- a/bun.lock
+++ b/bun.lock
@@ -172,6 +172,7 @@
       "name": "test",
       "devDependencies": {
         "@elysiajs/eden": "catalog:",
+        "@types/bun": "catalog:types",
         "elysia": "catalog:",
         "vue": "catalog:ui",
         "zod": "catalog:",

--- a/test/events-dedup.test.ts
+++ b/test/events-dedup.test.ts
@@ -50,6 +50,7 @@ describe('Request deduplication', () => {
     eventsModule.__test.reset()
 
     // Mock globalThis.fetch to track calls and return valid ICS
+    // @ts-expect-error - Bun's fetch type includes extra properties we don't need to mock
     fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
       fetchCallCount++
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url

--- a/test/ops.routes.test.ts
+++ b/test/ops.routes.test.ts
@@ -5,7 +5,8 @@ import { treaty } from '@elysiajs/eden'
 import { configureApiDbMock, installApiDbMock, resetApiDbMockStores } from './helpers/api-db-mock'
 
 describe('Ops routes', () => {
-  let app: Elysia
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let app: any
   let api: ReturnType<typeof treaty>
 
   beforeAll(async () => {

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "@elysiajs/eden": "catalog:",
+    "@types/bun": "catalog:types",
     "elysia": "catalog:",
     "vue": "catalog:ui",
     "zod": "catalog:"

--- a/test/plannings.range.test.ts
+++ b/test/plannings.range.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { Elysia } from 'elysia'
+import { flattenedPlannings } from '@api/plannings'
+import { getApiDbMockStores, installApiDbMock, resetApiDbMockStores } from './helpers/api-db-mock'
+
+type CalEvent = {
+  uid: string
+  summary: string
+  startDate: Date
+  endDate: Date
+  location: string
+  description: string
+}
+
+const sampleEvents: CalEvent[] = [
+  {
+    uid: 'evt-1',
+    summary: 'Event 1',
+    startDate: new Date('2026-01-01T10:00:00Z'),
+    endDate: new Date('2026-01-01T12:00:00Z'),
+    location: 'Room A',
+    description: 'Desc 1',
+  },
+  {
+    uid: 'evt-2',
+    summary: 'Event 2',
+    startDate: new Date('2026-02-01T10:00:00Z'),
+    endDate: new Date('2026-02-01T12:00:00Z'),
+    location: 'Room B',
+    description: 'Desc 2',
+  },
+  {
+    uid: 'evt-3',
+    summary: 'Event 3',
+    startDate: new Date('2026-03-01T10:00:00Z'),
+    endDate: new Date('2026-03-01T12:00:00Z'),
+    location: 'Room C',
+    description: 'Desc 3',
+  },
+]
+
+function buildICS(events: CalEvent[]) {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//PlanningSup Test//EN',
+    ...events.flatMap((e) => [
+      'BEGIN:VEVENT',
+      `UID:${e.uid}`,
+      `DTSTART:${toICS(e.startDate)}`,
+      `DTEND:${toICS(e.endDate)}`,
+      `SUMMARY:${e.summary}`,
+      `LOCATION:${e.location}`,
+      `DESCRIPTION:${e.description}`,
+      'END:VEVENT',
+    ]),
+    'END:VCALENDAR',
+  ]
+  return lines.join('\r\n')
+}
+
+function toICS(d: Date) {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+}
+
+describe('Plannings range filtering', () => {
+  let app: any
+  const anyLeaf = flattenedPlannings.find(p => Boolean(p.url)) || flattenedPlannings[0]
+  const targetFullId = anyLeaf.fullId
+  let targetUrl: string
+  const originalFetch = globalThis.fetch
+
+  let backupStore: Record<string, { events: CalEvent[], updatedAt: Date } | undefined>
+  let refreshQueueStore: Map<string, { priority: number }>
+
+  beforeAll(async () => {
+    process.env.RUN_JOBS = 'false'
+    process.env.NODE_ENV = 'test'
+    installApiDbMock()
+    resetApiDbMockStores()
+    ;({ backupStore, refreshQueueStore } = getApiDbMockStores())
+
+    targetUrl = 'http://localhost/__fake_ics_range__'
+    ;(anyLeaf as any).url = targetUrl
+
+    // @ts-expect-error bun types
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith(targetUrl)) {
+        return new Response(buildICS(sampleEvents), {
+          status: 200,
+          headers: { 'Content-Type': 'text/calendar' },
+        })
+      }
+      return originalFetch(input as any)
+    }
+
+    const { default: planningsRoutes } = await import('@api/routes/plannings')
+    app = new Elysia().use(planningsRoutes)
+  })
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('filters events locally by range', async () => {
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&from=2026-01-15&to=2026-02-15`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.status).toBe('ok')
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].summary).toBe('Event 2')
+  })
+
+  it('handles "from" only', async () => {
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&from=2026-02-15`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.status).toBe('ok')
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].summary).toBe('Event 3')
+  })
+
+  it('handles "to" only', async () => {
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&to=2026-01-15`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.status).toBe('ok')
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].summary).toBe('Event 1')
+  })
+
+  it('returns 400 for range too large', async () => {
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&from=2020-01-01&to=2025-01-01`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Range too large (max 2 years)')
+  })
+
+  it('returns 400 for invalid dates', async () => {
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&from=invalid-date`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Invalid range dates')
+  })
+
+  it('returns 400 for range with onlyDb=true', async () => {
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&from=2025-01-01&onlyDb=true`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Range filtering is only supported for network-first calls')
+  })
+
+  it('does NOT enqueue refresh or write backup when range is used', async () => {
+    backupStore[targetFullId] = undefined
+    refreshQueueStore.clear()
+
+    const url = `http://local/plannings/${encodeURIComponent(targetFullId)}?events=true&from=2025-01-01&to=2025-01-02`
+    const res = await app.handle(new Request(url))
+    expect(res.status).toBe(200)
+
+    // Give some time for async ops (even if they should NOT happen)
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(backupStore[targetFullId]).toBeUndefined()
+    expect(refreshQueueStore.has(targetFullId)).toBeFalse()
+  })
+})

--- a/test/plannings.range.test.ts
+++ b/test/plannings.range.test.ts
@@ -65,6 +65,7 @@ function toICS(d: Date) {
 }
 
 describe('Plannings range filtering', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let app: any
   const anyLeaf = flattenedPlannings.find(p => Boolean(p.url)) || flattenedPlannings[0]
   const targetFullId = anyLeaf.fullId

--- a/test/plannings.routes.test.ts
+++ b/test/plannings.routes.test.ts
@@ -85,7 +85,7 @@ function toICS(d: Date) {
 }
 
 describe('Plannings routes (no util mocks, fetch+DB mocked)', () => {
-  let app: Elysia
+  let app: any
   let api: ReturnType<typeof treaty>
 
   const anyLeaf = flattenedPlannings.find(p => Boolean(p.url)) || flattenedPlannings[0]

--- a/test/plannings.routes.test.ts
+++ b/test/plannings.routes.test.ts
@@ -85,6 +85,7 @@ function toICS(d: Date) {
 }
 
 describe('Plannings routes (no util mocks, fetch+DB mocked)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let app: any
   let api: ReturnType<typeof treaty>
 
@@ -239,7 +240,7 @@ describe('Plannings routes (no util mocks, fetch+DB mocked)', () => {
 
     const ok = await waitFor(() => Array.isArray(backupStore[targetFullId]?.events))
     expect(ok).toBeTrue()
-    expect((backupStore[targetFullId]?.events as any[]).length).toBe(sampleEvents.length)
+    expect(backupStore[targetFullId]!.events.length).toBe(sampleEvents.length)
   })
 
   it('uses backup events when ICS fetch fails', async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,33 +1,27 @@
 {
-  "extends": "config/typescript/base.json",
+  "extends": "../packages/config/typescript/base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "..",
     "module": "ESNext",
     "target": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["bun-types"],
+    "jsx": "react-jsx",
+    "types": ["@types/bun"],
     "noEmit": true,
     "skipLibCheck": true,
     "paths": {
-      "@api": ["../apps/api/src/index.ts"],
-      "@api/*": ["../apps/api/src/*"],
-      "@web/*": ["../apps/web/src/*"],
-      "@libs": ["../packages/libs/src/index.ts"],
-      "@libs/*": ["../packages/libs/src/*"],
-      "@plannings": ["../resources/plannings"]
+      "@api": ["apps/api/src/index.ts"],
+      "@api/*": ["apps/api/src/*"],
+      "@web/*": ["apps/web/src/*"],
+      "@libs": ["packages/libs/src/index.ts"],
+      "@libs/*": ["packages/libs/src/*"],
+      "@plannings": ["resources/plannings"]
     }
   },
   "include": [
-    "../apps",
-    "../packages",
-    "../resources",
-    "../scripts",
-    "../test"
+    "./**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "dist",
-    "build",
-    "drizzle.config.ts"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
- Add 'from' and 'to' query parameters to /plannings/:fullId
- Implement range validation (max 2 years)
- Support range filtering in ICS fetch via templates and local filtering
- Ensure range requests don't trigger background refreshes or backup writes
- Add comprehensive tests for range filtering logic