### PR TITLE
fix: restore schedule-x z-indexes, fallback CORS trustedOrigins

### DIFF
--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -53,7 +53,7 @@ function getConfig() {
 
     // Better-Auth
     authEnabled: env('AUTH_ENABLED', { default: false }),
-    trustedOrigins: env('TRUSTED_ORIGINS')?.split(',').map(s => s.trim()),
+    trustedOrigins: env('TRUSTED_ORIGINS')?.split(',').map(s => s.trim()) ?? [rawPublicOrigin],
 
     auth: {
       discord: {

--- a/apps/web/src/styles/schedule-x.css
+++ b/apps/web/src/styles/schedule-x.css
@@ -1,4 +1,9 @@
 :root {
+  /* Restore low z-indexes (schedule-x 4.3.1 bumped to 100+) */
+  --sx-z-index-week-header: 2;
+  --sx-z-index-event-modal: 3;
+  --sx-calendar-header-popup-z-index: 4;
+
   --sx-spacing-padding3: 6px;
   --sx-font-extra-small: 0.82rem;
   --sx-font-extra-large: 1rem;


### PR DESCRIPTION
## Summary
- **Z-index**: schedule-x 4.3.1 bumped internal z-indexes from 2 to 100+ (week header, event modal, header popup). This caused dropdowns (e.g. user menu with `z-10`) to render behind the calendar. Fix: override their CSS vars back to low values in `schedule-x.css`.
- **CORS Vary header**: when `TRUSTED_ORIGINS` env is unset, `cors({ origin: undefined })` defaults to `origin: true` → `Vary: *` on all responses → browser and SW can't cache anything (fonts, CSS, JS). Fix: fallback to `[publicOrigin]` so cors always gets a proper origin array.

## Test plan
- [ ] Dropdown menu renders above the calendar
- [ ] No `Vary: *` in response headers when `TRUSTED_ORIGINS` is unset
- [ ] Font flicker gone on dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)