### PR TITLE
feat: show git commit SHA in logo tooltip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,18 @@ COPY /test ./test
 ENV NODE_ENV=test
 RUN bun run test:unit
 
+COPY .git/HEAD /tmp/git/HEAD
+COPY .git/refs /tmp/git/refs
+RUN set -e; \
+    head=$(cat /tmp/git/HEAD); \
+    if echo "$head" | grep -q '^ref: '; then \
+      ref=$(echo "$head" | sed 's/^ref: //'); \
+      sha=$(cat "/tmp/git/$ref"); \
+    else \
+      sha="$head"; \
+    fi; \
+    printf '%.7s' "$sha" > /tmp/commit_sha
+
 
 ##########################################################
 FROM cgr.dev/chainguard/glibc-dynamic:latest
@@ -61,6 +73,8 @@ COPY --from=build /app/apps/api/server ./server
 COPY --from=build /app/apps/web/dist ./web/dist/
 
 COPY --from=build /app/plannings ./plannings
+
+COPY --from=build /tmp/commit_sha ./commit_sha
 
 ENV NODE_ENV=production
 ENV PORT=20000

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,10 +31,13 @@ await initDb(db).then(() => {
   jobs.start(db)
 })
 
+const commitSha = await Bun.file(path.join(process.cwd(), 'commit_sha')).text().catch(() => '')
+
 const RUNTIME_CONFIG = {
   authEnabled: config.authEnabled,
   plausible: config.plausible,
   donationLinks: config.donationLinks,
+  commitSha,
 }
 
 export const app = new Elysia()

--- a/apps/web/src/components/layout/AppNavbar.vue
+++ b/apps/web/src/components/layout/AppNavbar.vue
@@ -9,7 +9,8 @@ import { usePlanningData } from '@web/composables/usePlanningData'
 import { usePlanningPickerController } from '@web/composables/usePlanningPickerController'
 import { computed, onBeforeUnmount, onMounted, useTemplateRef } from 'vue'
 
-const imageTooltipText = `${__APP_DISPLAY_NAME__ || ''} ${__APP_VERSION__ || ''}`.trim()
+const commitSha = globalThis.__APP_CONFIG__?.commitSha
+const imageTooltipText = `${__APP_DISPLAY_NAME__ || ''} ${__APP_VERSION__ || ''}${commitSha ? ` (${commitSha})` : ''}`.trim()
 
 const { titles, planningFullIds, networkFailures, syncing, hasEvents } = usePlanningData()
 const isOnline = useOnline()

--- a/apps/web/src/globals.d.ts
+++ b/apps/web/src/globals.d.ts
@@ -10,6 +10,7 @@ declare global {
       name: string
       url: string
     }[]
+    commitSha?: string
   } | undefined
 }
 


### PR DESCRIPTION
## Summary
- Extract short commit hash from `.git/HEAD` + `.git/refs` at Docker build time (placed after tests to preserve cache)
- API reads `/app/commit_sha` at startup and serves it via `/config.js` runtime config
- Logo tooltip now shows `PlanningSup 3.3.1 (abc1234)`

## Test plan
- [x] Lint + typecheck pass
- [x] Docker build succeeds, commit SHA file contains correct hash
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)