### PR TITLE
build: drop Node from Docker, patch @volar/typescript for Bun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 ARG BUN_VERSION=1
 FROM oven/bun:${BUN_VERSION} AS build
 
-RUN apt-get update && apt-get install -y curl && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && apt-get install -y nodejs
-
 WORKDIR /app
 
 COPY /scripts/run.ts ./scripts/run.ts
 
 # Cache packages
-# COPY patches patches
+COPY patches patches
 COPY package.json package.json
 COPY bun.lock bun.lock
 

--- a/bun.lock
+++ b/bun.lock
@@ -187,9 +187,12 @@
   "trustedDependencies": [
     "@tailwindcss/oxide",
     "esbuild",
-    "sharp",
     "core-js",
+    "sharp",
   ],
+  "patchedDependencies": {
+    "@volar/typescript@2.4.28": "patches/@volar%2Ftypescript@2.4.28.patch",
+  },
   "catalog": {
     "@better-auth/passkey": "1.5.6",
     "@elysiajs/eden": "1.4.9",

--- a/package.json
+++ b/package.json
@@ -99,5 +99,8 @@
     "*.{ts,tsx,vue}": [
       "bun run typecheck"
     ]
+  },
+  "patchedDependencies": {
+    "@volar/typescript@2.4.28": "patches/@volar%2Ftypescript@2.4.28.patch"
   }
 }

--- a/patches/@volar%2Ftypescript@2.4.28.patch
+++ b/patches/@volar%2Ftypescript@2.4.28.patch
@@ -1,0 +1,74 @@
+diff --git a/lib/quickstart/runTsc.js b/lib/quickstart/runTsc.js
+index 9de27714a40531e5b1ade7e0686c937a327a8d38..3cefd3b4b79b643853a3fde7ffa61f1b90a57272 100644
+--- a/lib/quickstart/runTsc.js
++++ b/lib/quickstart/runTsc.js
+@@ -20,35 +20,33 @@ function runTsc(tscPath, options, _getLanguagePlugins, typescriptObject) {
+         extraExtensionsToRemove = options.extraExtensionsToRemove;
+     }
+     const proxyApiPath = require.resolve('../node/proxyCreateProgram');
+-    const readFileSync = fs.readFileSync;
+-    fs.readFileSync = (...args) => {
+-        if (args[0] === tscPath) {
+-            let tsc = readFileSync(...args);
+-            try {
+-                return transformTscContent(tsc, proxyApiPath, extraSupportedExtensions, extraExtensionsToRemove, __filename, typescriptObject);
+-            }
+-            catch {
+-                // Support the tsc shim used in Typescript v5.7 and up
+-                const requireRegex = /module\.exports\s*=\s*require\((?:"|')(?<path>\.\/\w+\.js)(?:"|')\)/;
+-                const requirePath = requireRegex.exec(tsc)?.groups?.path;
+-                if (requirePath) {
+-                    tsc = readFileSync(path.join(path.dirname(tscPath), requirePath), 'utf8');
+-                    return transformTscContent(tsc, proxyApiPath, extraSupportedExtensions, extraExtensionsToRemove, __filename, typescriptObject);
+-                }
+-                else {
+-                    throw new Error('Failed to locate tsc module path from shim');
+-                }
+-            }
+-        }
+-        return readFileSync(...args);
+-    };
+-    try {
+-        return require(tscPath);
++    const Module = require('module');
++    // Mirror the TS v5.7+ tsc shim behavior: enable the V8/JSC bytecode cache
++    // so the (huge) transformed tsc source is compiled once and reused on
++    // subsequent invocations. Supported by Node 22+ and Bun 1.2+.
++    try { Module.enableCompileCache?.(); } catch {}
++    // Detect the tsc shim used in TypeScript v5.7+: a tiny preamble that
++    // re-exports the actual compiler from a sibling file. Resolve through it
++    // up front so transformTscContent operates on the real source.
++    const shimRegex = /module\.exports\s*=\s*require\(["'](?<path>\.\/\w+\.js)["']\)/;
++    let compilePath = tscPath;
++    let tsc = fs.readFileSync(tscPath, 'utf8');
++    const shimMatch = shimRegex.exec(tsc);
++    if (shimMatch?.groups?.path) {
++        compilePath = path.join(path.dirname(tscPath), shimMatch.groups.path);
++        tsc = fs.readFileSync(compilePath, 'utf8');
+     }
+-    finally {
+-        fs.readFileSync = readFileSync;
+-        delete require.cache[tscPath];
++    // Strip UTF-8 BOM — Node's Module._extensions['.js'] does this before
++    // compiling; we bypass that wrapper so we replicate it here.
++    let transformed = transformTscContent(tsc, proxyApiPath, extraSupportedExtensions, extraExtensionsToRemove, __filename, typescriptObject);
++    if (transformed.charCodeAt(0) === 0xFEFF) {
++        transformed = transformed.slice(1);
+     }
++
++    const m = new Module(compilePath);
++    m.filename = compilePath;
++    m.paths = Module._nodeModulePaths(path.dirname(compilePath));
++    m._compile(transformed, compilePath);
+ }
+ /**
+  * Replaces the code of typescript to add support for additional extensions and language plugins.
+@@ -95,7 +93,7 @@ function transformTscContent(tsc, proxyApiPath, extraSupportedExtensions, extraE
+         + s.replace('createProgram', '_createProgram'));
+     return tsc;
+ }
+-function replace(text, search, replace) {
++function replace(text, ...[search, replace]) {
+     const before = text;
+     text = text.replace(search, replace);
+     const after = text;


### PR DESCRIPTION
## Summary

- Drops Node 24 from the build stage of `Dockerfile` (was only there for `vue-tsc`)
- Adds a `bun patch` on `@volar/typescript@2.4.28` to fix the long-standing incompat where Bun's module loader does not honor `fs.readFileSync` monkey-patching — the trick Volar uses to inject `.vue` extension support into TypeScript (Bun issue 4754, opened 2023).
- The patch replaces the monkey-patch with a direct `Module#_compile` call, honored by both Node and Bun. Same fix lives on a fork at [kernoeb/volar.js@fix-bun-vue-tsc](https://github.com/kernoeb/volar.js/tree/fix-bun-vue-tsc).

## What the patch does

| Before | After |
|---|---|
| Monkey-patches `fs.readFileSync` to intercept Node's CJS loader read of `tsc.js` | Reads `tsc.js` directly, transforms it, then `Module#_compile`s the result |
| Uses a thrown `transformTscContent` failure as the "this is the v5.7+ shim" signal | Detects the shim with a regex up front; real transform failures now surface their real error |
| No BOM strip (relied on Node's `Module._extensions['.js']` wrapper) | Explicitly strips UTF-8 BOM before compiling |
| No compile cache (the v5.7+ tsc shim called `enableCompileCache()`, our patch bypassed it) | Calls `Module.enableCompileCache()` to mirror the shim |

## Test plan

- [x] `docker build --target build` passes end-to-end in ~44s (was building successfully with Node previously)
- [x] `bun install` re-applies the patch automatically (verified on clean `rm -rf node_modules && bun install`)
- [x] `bun run typecheck` (= `vue-tsc -b --force`) exits 0
- [x] `bun run test:unit` — 136 tests, 5704 expect() calls, all green
- [ ] Production image runs and serves `/api/ping` as before (smoke-test on test server)

## Notes

- `@volar/typescript` 2.4.28 is the version currently pinned via `bun.lock`. If volar bumps minor we'll need to regenerate the patch — `bun patch` will fail-loud on hash mismatch.
- The fork is not yet a PR upstream — we keep the local patch until Volar merges it.