### PR TITLE
fix(plannings): follow symlinks when scanning plannings dir

### DIFF
--- a/apps/api/src/plannings/index.ts
+++ b/apps/api/src/plannings/index.ts
@@ -73,6 +73,9 @@ for await (const file of glob.scan({
   cwd: planningsLocation,
   onlyFiles: true,
   absolute: true,
+  // Follow symlinks so plannings mounted via Kubernetes ConfigMap volumes
+  // (each file is a symlink to ..data/<file>) are discovered.
+  followSymlinks: true,
 })) {
   const parsed = PlanningSchema.parse(await Bun.file(file).json())
   const id = path.basename(file, '.json')


### PR DESCRIPTION
## Problem

When the plannings directory is overwritten via a **Kubernetes ConfigMap volume mount**, every file is exposed as a symlink:

```
imt-atlantique.json -> ..data/imt-atlantique.json
..data              -> ..2026_06_18_09_03_30.3915035025/
```

`Bun.Glob.scan` defaults to `followSymlinks: false`, so with `onlyFiles: true` these symlinked entries are skipped → **0 plannings loaded** (server starts fine, but the planning tree is empty).

## Fix

Pass `followSymlinks: true` to the `glob.scan(...)` in `apps/api/src/plannings/index.ts`.

## Verification

Reproduced the exact ConfigMap symlink layout (`..data` + per-file symlinks) and ran the glob both ways:

| scan | result |
|------|--------|
| `followSymlinks: false` (before) | **0 files** |
| `followSymlinks: true` (after)  | **1 file** ✅ |

Reading the resolved path right after (`Bun.file(file).json()`) follows the symlink transparently, so no other change is needed. The non-symlink case is unaffected. Typecheck + lint pass.

## Notes for K8s users

Without this change, alternatives that need no code change are: mount each file with `subPath:` (real bind-mounted file), or set `PLANNINGS_LOCATION=/app/plannings/..data` (the inner files are real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)