### PR TITLE
fix(auth): don't crash extension OAuth callback when a stray 'browser' global is present

### DIFF
--- a/apps/api/src/utils/auth-html.tsx
+++ b/apps/api/src/utils/auth-html.tsx
@@ -160,22 +160,29 @@ export default new Elysia().use(html()).get('/auth/auto-redirect/:provider', asy
         <script>
           {`
             function sendMessageToExtension(message) {
-              if (typeof browser !== 'undefined' && browser.runtime && browser.runtime.sendMessage) {
-                // For Firefox and browsers supporting webextension-polyfill
-                if (${!!config.firefoxExtensionId}) return browser.runtime.sendMessage('${config.firefoxExtensionId || '*'}', message);
-              } else if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
-                // For Chrome
+              var firefoxId = ${JSON.stringify(config.firefoxExtensionId || '')};
+              var chromeId = ${JSON.stringify(config.chromeExtensionId || '')};
+              // Detect the engine explicitly: a stray 'browser' global (injected by an
+              // unrelated extension's webextension-polyfill) must NOT route a Chromium
+              // page down the Firefox branch — that returned undefined and crashed on .then.
+              var isFirefox = typeof navigator !== 'undefined' && /firefox/i.test(navigator.userAgent);
+
+              if (isFirefox && firefoxId && typeof browser !== 'undefined' && browser.runtime && browser.runtime.sendMessage) {
+                // Firefox (webextension-polyfill: returns a Promise)
+                return browser.runtime.sendMessage(firefoxId, message);
+              }
+              if (chromeId && typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
+                // Chromium (Chrome, Brave, Edge): callback API
                 return new Promise((resolve, reject) => {
-                  if (${!!config.chromeExtensionId}) chrome.runtime.sendMessage('${config.chromeExtensionId || '*'}', message, (response) => {
+                  chrome.runtime.sendMessage(chromeId, message, (response) => {
                     console.log('chrome.runtime.sendMessage response:', response);
                     const err = chrome.runtime.lastError;
                     if (err) reject(err);
                     else resolve(response);
                   });
                 });
-              } else {
-                return Promise.reject(new Error('No extension runtime found'));
               }
+              return Promise.reject(new Error('No extension runtime found for this browser'));
             }
 
             window.addEventListener('load', () => {


### PR DESCRIPTION
The extension sign-in callback page (`/api/auth/auto-redirect/:provider` for `client=extension`) crashed with `Uncaught TypeError: Cannot read properties of undefined (reading 'then')` on Chromium browsers whenever a `browser` global was present on the page — commonly injected by an unrelated extension's `webextension-polyfill`.

## Root cause
`sendMessageToExtension()` checked `typeof browser !== 'undefined'` first. With a `browser` global present but **no `FIREFOX_EXTENSION_ID`** configured, it entered the Firefox branch, the inner `if(false)` returned nothing → `undefined`, and the subsequent `.then()` threw. The working `chrome.runtime.sendMessage` path was never reached, so extension login silently failed.

## Fix
Select the messaging runtime by the actual engine (UA) **and** only when the matching extension id is configured, with a clean rejection fallback. A stray `browser` global on a Chromium page can no longer misroute to the Firefox branch.

Verified: with `chromeId` set / `firefoxId` empty and both `browser`+`chrome` globals present, the function now returns a Promise that resolves via the Chrome branch (previously `undefined`). Confirmed the live crash on Brave (both globals present) and the corrected path. Lint + typecheck pass.